### PR TITLE
fix link URLs in rss feed

### DIFF
--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -14,7 +14,7 @@ export const get = async () => {
 		description: '',
 		site,
 		items: allPosts.map((post) => ({
-			link: site + 'posts/' + post.slug,
+			link: site + '/posts/' + post.slug,
 			title: post.data.title,
 			pubDate: post.data.publishDate,
 			content: sanitizeHtml(marked(post.data.description ?? '')),


### PR DESCRIPTION
I was going to tell you about this, but then found it pretty quickly so I made a PR.

Links are currently being generated like so:

```
<link>https://blog.nobbz.devposts/2022-09-17-callpackage-a-tool-for-the-lazy</link>
```